### PR TITLE
ci: skip SonarQube for dependabot | SRENEW-1304

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,6 @@ version: 2
 updates:
   # Enable version updates for npm
   - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: '/'
-    # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: 'daily'
+      interval: 'weekly'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       - run: |
           npm run all
       - uses: sonarsource/sonarqube-scan-action@v1.1.0
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           args: >
             -D sonar.projectKey=supplypike_jira-pr-link-action


### PR DESCRIPTION
also run dependabot weekly instead of daily