### PR TITLE
[SRENEW-3365] move author check before input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ These are some of the supported input parameters of action.
 | **`jira-host`**      | JIRA server URL                              | YES           |                                                                                               |
 | **`jira-email`**     | Login of JIRA user                           | YES           |                                                                                               |
 | **`jira-api-token`** | The token that goes with the `jira-email`    | YES           |                                                                                               |
-| **`ignore-author`**  | Newline seperated list of PR authors to ignore | NO            |                                                                                               |
+| **`ignore-author`**  | Newline separated list of PR authors to ignore | NO            |                                                                                               |

--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ These are some of the supported input parameters of action.
 | **`jira-host`**      | JIRA server URL                              | YES           |                                                                                               |
 | **`jira-email`**     | Login of JIRA user                           | YES           |                                                                                               |
 | **`jira-api-token`** | The token that goes with the `jira-email`    | YES           |                                                                                               |
-| **`ignore-author`**  | Comma seperated list of PR authors to ignore | NO            |                                                                                               |
+| **`ignore-author`**  | Newline seperated list of PR authors to ignore | NO            |                                                                                               |

--- a/__tests__/pr.test.ts
+++ b/__tests__/pr.test.ts
@@ -59,13 +59,6 @@ describe('#validate', () => {
     expect(await validate(mock, options)).toEqual(true)
   })
 
-  test('valid if ignoreAuthor matches', async () => {
-    options.ignoreAuthor = ['dependabot[bot]']
-    mock.pull_request.user.login = 'dependabot[bot]'
-
-    expect(await validate(mock, options)).toEqual(true)
-  })
-
   test('invalid when jira card does not exist', async () => {
     vi.spyOn(JiraClientImpl.prototype, 'issueExists').mockResolvedValue(false)
 
@@ -97,16 +90,24 @@ describe('#process', () => {
     'jira-email': 'test@example.com',
     'jira-api-token': '1234567890',
   }
+  let mockIgnoreAuthors: string[] = []
   beforeEach(() => {
     context = {
       eventName: 'pull_request',
       payload: pr,
     }
+    mockIgnoreAuthors = []
     mockValidate.mockResolvedValue(true)
     setFailedSpy = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
     vi.spyOn(core, 'getInput').mockImplementation(
       (name: string) => mockInputs[name],
     )
+    vi.spyOn(core, 'getMultilineInput').mockImplementation((name: string) => {
+      if (name === 'ignore-author') {
+        return mockIgnoreAuthors
+      }
+      return []
+    })
   })
 
   test('calls validate w/ input options', async () => {
@@ -130,6 +131,31 @@ describe('#process', () => {
     }
     await process(context, mockValidate)
     expect(mockValidate).not.toHaveBeenCalled()
+    expect(setFailedSpy).not.toHaveBeenCalled()
+  })
+
+  test('skips validation when author is in ignore list', async () => {
+    mockIgnoreAuthors = ['dependabot[bot]', 'renovate[bot]']
+    const mockPR = JSON.parse(JSON.stringify(pr))
+    mockPR.pull_request.user.login = 'dependabot[bot]'
+    context.payload = mockPR
+
+    await process(context, mockValidate)
+
+    expect(mockValidate).not.toHaveBeenCalled()
+    expect(setFailedSpy).not.toHaveBeenCalled()
+  })
+
+  test('continues validation when author is not in ignore list', async () => {
+    mockIgnoreAuthors = ['dependabot[bot]']
+    const mockPR = JSON.parse(JSON.stringify(pr))
+    mockPR.pull_request.user.login = 'some-user'
+    context.payload = mockPR
+    mockValidate.mockResolvedValue(true)
+
+    await process(context, mockValidate)
+
+    expect(mockValidate).toHaveBeenCalledTimes(1)
     expect(setFailedSpy).not.toHaveBeenCalled()
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: 'JIRA Project'
   ignore-author:
     required: false
-    description: 'comma seperated list of authors to skip check for'
+    description: 'newline separated list of authors to skip check for'
   jira-host:
     required: true
     description: 'JIRA Domain'

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -19431,6 +19431,13 @@ function debug(message) {
 function error(message, properties = {}) {
 	issueCommand("error", toCommandProperties(properties), message instanceof Error ? message.toString() : message);
 }
+/**
+* Writes info to log with console.log.
+* @param message info message
+*/
+function info(message) {
+	process.stdout.write(message + os.EOL);
+}
 
 //#endregion
 //#region node_modules/axios/lib/helpers/bind.js
@@ -45328,6 +45335,9 @@ var JiraClientImpl = class {
 
 //#endregion
 //#region src/options.ts
+function getIgnoreAuthors() {
+	return getMultilineInput("ignore-author") || [];
+}
 function getInput() {
 	return {
 		project: getInput$1("project", { required: true }),
@@ -45348,6 +45358,12 @@ async function process$1(context, isValid = validate) {
 		return;
 	}
 	const ev = context.payload;
+	const login = ev.pull_request.user.login;
+	const ignoreAuthors = getIgnoreAuthors();
+	for (const author of ignoreAuthors) if (login && login.toLowerCase() === author.toLowerCase()) {
+		info(`Pull request created by ${login}, which is in the ignore list. Skipping validation.`);
+		return;
+	}
 	if (!await isValid(ev, getInput())) setFailed("Invalid Pull Request: missing JIRA project in title or branch");
 }
 /**
@@ -45363,7 +45379,6 @@ async function validate(event, options) {
 	debug(`author ${event.pull_request.user.login.toLowerCase()}`);
 	debug(`title ${event.pull_request.title}`);
 	debug(`head ${event.pull_request.head.ref}`);
-	for (const author of options.ignoreAuthor) if (event.pull_request.user.login.toLowerCase() === author.toLowerCase()) return true;
 	const titleMatch = event.pull_request.title.match(re) || [];
 	const refMatch = event.pull_request.head.ref.match(re) || [];
 	const matches = [...titleMatch, ...refMatch];

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -45341,7 +45341,7 @@ function getIgnoreAuthors() {
 function getInput() {
 	return {
 		project: getInput$1("project", { required: true }),
-		ignoreAuthor: getMultilineInput("ignore-author") || [],
+		ignoreAuthor: getIgnoreAuthors(),
 		jira: {
 			host: getInput$1("jira-host", { required: true }),
 			email: getInput$1("jira-email", { required: true }),
@@ -45360,7 +45360,7 @@ async function process$1(context, isValid = validate) {
 	const ev = context.payload;
 	const login = ev.pull_request.user.login;
 	const ignoreAuthors = getIgnoreAuthors();
-	for (const author of ignoreAuthors) if (login && login.toLowerCase() === author.toLowerCase()) {
+	for (const author of ignoreAuthors) if (login.toLowerCase() === author.toLowerCase()) {
 		info(`Pull request created by ${login}, which is in the ignore list. Skipping validation.`);
 		return;
 	}

--- a/src/options.ts
+++ b/src/options.ts
@@ -7,6 +7,10 @@ export interface Options {
   jira: JiraConfig
 }
 
+export function getIgnoreAuthors(): string[] {
+  return core.getMultilineInput('ignore-author') || []
+}
+
 export function getInput(): Options {
   const project = core.getInput('project', { required: true })
   const ignoreAuthor = core.getMultilineInput('ignore-author') || []

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,7 +13,7 @@ export function getIgnoreAuthors(): string[] {
 
 export function getInput(): Options {
   const project = core.getInput('project', { required: true })
-  const ignoreAuthor = core.getMultilineInput('ignore-author') || []
+  const ignoreAuthor = getIgnoreAuthors()
   const jiraHost = core.getInput('jira-host', { required: true })
   const jiraEmail = core.getInput('jira-email', { required: true })
   const jiraToken = core.getInput('jira-api-token', { required: true })

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -2,8 +2,7 @@ import * as core from '@actions/core'
 import type { Context } from '@actions/github'
 import type { PullRequestEvent } from '@octokit/webhooks-types'
 import { JiraClientImpl } from './jira'
-import { getInput, type Options } from './options'
-import { getIgnoreAuthors } from './options.js'
+import { getInput, type Options, getIgnoreAuthors } from './options'
 
 export async function process(
   context: Context,
@@ -20,7 +19,7 @@ export async function process(
 
   // check ignore authors before calling isValid or getInput to avoid unnecessary errors or api calls
   for (const author of ignoreAuthors) {
-    if (login && login.toLowerCase() === author.toLowerCase()) {
+    if (login.toLowerCase() === author.toLowerCase()) {
       core.info(
         `Pull request created by ${login}, which is in the ignore list. Skipping validation.`,
       )

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -3,6 +3,7 @@ import type { Context } from '@actions/github'
 import type { PullRequestEvent } from '@octokit/webhooks-types'
 import { JiraClientImpl } from './jira'
 import { getInput, type Options } from './options'
+import { getIgnoreAuthors } from './options.js'
 
 export async function process(
   context: Context,
@@ -14,6 +15,19 @@ export async function process(
   }
 
   const ev = context.payload as PullRequestEvent
+  const login = ev.pull_request.user.login
+  const ignoreAuthors = getIgnoreAuthors()
+
+  // check ignore authors before calling isValid or getInput to avoid unnecessary errors or api calls
+  for (const author of ignoreAuthors) {
+    if (login && login.toLowerCase() === author.toLowerCase()) {
+      core.info(
+        `Pull request created by ${login}, which is in the ignore list. Skipping validation.`,
+      )
+      return
+    }
+  }
+
   const valid = await isValid(ev, getInput())
 
   if (!valid) {
@@ -41,12 +55,6 @@ export async function validate(
   core.debug(`author ${event.pull_request.user.login.toLowerCase()}`)
   core.debug(`title ${event.pull_request.title}`)
   core.debug(`head ${event.pull_request.head.ref}`)
-
-  for (const author of options.ignoreAuthor) {
-    if (event.pull_request.user.login.toLowerCase() === author.toLowerCase()) {
-      return true
-    }
-  }
 
   const titleMatch = event.pull_request.title.match(re) || []
   const refMatch = event.pull_request.head.ref.match(re) || []


### PR DESCRIPTION
Currently the action fails if inputs are missing. However, if the action should be ignored due to the author we do not need to validate any of the other inputs.